### PR TITLE
chore: release v0.7.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.7.1](https://github.com/Boshen/criterion2.rs/compare/v0.7.0...v0.7.1) - 2024-04-06
+
+### Added
+- allow async setup for async bencher ([#6](https://github.com/Boshen/criterion2.rs/pull/6))
 - MSRV bumped to 1.70
 
 ## [0.5.1] - 2023-05-26

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -389,7 +389,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "0.7.0" # When bumping: * Update version numbers in the book;
+version = "0.7.1"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Jorge Aparicio <japaricious@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 0.7.0 -> 0.7.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.7.1](https://github.com/Boshen/criterion2.rs/compare/v0.7.0...v0.7.1) - 2024-04-06

### Added
- allow async setup for async bencher ([#6](https://github.com/Boshen/criterion2.rs/pull/6))
- MSRV bumped to 1.70
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).