### PR TITLE
chore: release v0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.8.0](https://github.com/Boshen/criterion2.rs/compare/v0.7.2...v0.8.0) - 2024-04-29
+
+### Added
+- remove regex filter support to reduce compilation speed ([#15](https://github.com/Boshen/criterion2.rs/pull/15))
+
+### Other
+- add justfile
+- *(deps)* update rust crate codspeed to 2.6.0 ([#14](https://github.com/Boshen/criterion2.rs/pull/14))
+- *(deps)* update rust crate codspeed to 2.5.1 ([#13](https://github.com/Boshen/criterion2.rs/pull/13))
+- *(deps)* update rust crate codspeed to 2.5.0 ([#11](https://github.com/Boshen/criterion2.rs/pull/11))
+
 ## [0.7.2](https://github.com/Boshen/criterion2.rs/compare/v0.7.1...v0.7.2) - 2024-04-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -380,7 +380,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "0.7.2"
+version = "0.8.0"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "0.7.2"
+version = "0.8.0"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Jorge Aparicio <japaricious@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 0.7.2 -> 0.8.0 (⚠️ API breaking changes)

### ⚠️ `criterion2` breaking changes

```
--- failure enum_variant_missing: pub enum variant removed or renamed ---

Description:
A publicly-visible enum has at least one variant that is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.31.0/src/lints/enum_variant_missing.ron

Failed in:
  variant BenchmarkFilter::Regex, previously in file /tmp/.tmpJI1czf/criterion2/src/lib.rs:378
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.8.0](https://github.com/Boshen/criterion2.rs/compare/v0.7.2...v0.8.0) - 2024-04-29

### Added
- remove regex filter support to reduce compilation speed ([#15](https://github.com/Boshen/criterion2.rs/pull/15))

### Other
- add justfile
- *(deps)* update rust crate codspeed to 2.6.0 ([#14](https://github.com/Boshen/criterion2.rs/pull/14))
- *(deps)* update rust crate codspeed to 2.5.1 ([#13](https://github.com/Boshen/criterion2.rs/pull/13))
- *(deps)* update rust crate codspeed to 2.5.0 ([#11](https://github.com/Boshen/criterion2.rs/pull/11))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).