### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.10.0](https://github.com/Boshen/criterion2.rs/compare/v0.9.0...v0.10.0) - 2024-06-01
+
+### Added
+- [**breaking**] remove feature `html_reports`
+- [**breaking**] remove all plotting related functionalities ([#27](https://github.com/Boshen/criterion2.rs/pull/27))
+
+### Other
+- clean up ci
+- run fmt
+- remove unused dependencies
+
 ## [0.9.0](https://github.com/Boshen/criterion2.rs/compare/v0.8.0...v0.9.0) - 2024-05-28
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - [**breaking**] remove feature `html_reports`
 - [**breaking**] remove all plotting related functionalities ([#27](https://github.com/Boshen/criterion2.rs/pull/27))
 
-### Other
-- clean up ci
-- run fmt
-- remove unused dependencies
-
 ## [0.9.0](https://github.com/Boshen/criterion2.rs/compare/v0.8.0...v0.9.0) - 2024-05-28
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "0.9.0"
+version = "0.10.0"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 0.9.0 -> 0.10.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.10.0](https://github.com/Boshen/criterion2.rs/compare/v0.9.0...v0.10.0) - 2024-06-01

### Added
- [**breaking**] remove feature `html_reports`
- [**breaking**] remove all plotting related functionalities ([#27](https://github.com/Boshen/criterion2.rs/pull/27))

### Other
- clean up ci
- run fmt
- remove unused dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).