### PR TITLE
chore: release v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [0.11.0](https://github.com/Boshen/criterion2.rs/compare/v0.10.0...v0.11.0) - 2024-06-14
+
+### Added
+- [**breaking**] remove csv_output ([#33](https://github.com/Boshen/criterion2.rs/pull/33))
+- rm crate `criterion-macro`
+
+### Other
+- *(deps)* update dependency rust to v1.79.0 ([#35](https://github.com/Boshen/criterion2.rs/pull/35))
+- *(deps)* update rust crates ([#32](https://github.com/Boshen/criterion2.rs/pull/32))
+- *(deps)* lock file maintenance rust crates ([#31](https://github.com/Boshen/criterion2.rs/pull/31))
+- check unused dependencies
+
 ## [0.10.0](https://github.com/Boshen/criterion2.rs/compare/v0.9.0...v0.10.0) - 2024-06-01
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "0.10.0"
+version = "0.11.0"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "0.10.0"
+version = "0.11.0"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 0.10.0 -> 0.11.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.11.0](https://github.com/Boshen/criterion2.rs/compare/v0.10.0...v0.11.0) - 2024-06-14

### Added
- [**breaking**] remove csv_output ([#33](https://github.com/Boshen/criterion2.rs/pull/33))
- rm crate `criterion-macro`

### Other
- *(deps)* update dependency rust to v1.79.0 ([#35](https://github.com/Boshen/criterion2.rs/pull/35))
- *(deps)* update rust crates ([#32](https://github.com/Boshen/criterion2.rs/pull/32))
- *(deps)* lock file maintenance rust crates ([#31](https://github.com/Boshen/criterion2.rs/pull/31))
- check unused dependencies
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).