### PR TITLE
feat: add `Bencher::iter_with_setup_wrapper`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ This is fork is updated with:
 * `clap` replaced with [`bpaf`](https://github.com/pacak/bpaf) to reduce binary size and compilation time
 * merged the `criterion-plot` crate into `criterion2`
 * remove regex filter support to reduce compilation time
+* added `Bencher::iter_with_setup_wrapper` method
 
 ## Table of Contents
 


### PR DESCRIPTION
Add `Bencher::iter_with_setup_wrapper`. This API allows setup to be performed before each iteration of the benchmark, and the setup and routine functions can mutably borrow values from outside their closures.

This enables us to benchmark Oxc's components in isolation e.g. https://github.com/oxc-project/oxc/pull/5193.