### PR TITLE
Demonstrate tests malfunctioning

### DIFF
--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -93,6 +93,8 @@ fn test_creates_directory() {
     let dir = temp_dir();
     short_benchmark(&dir).bench_function("test_creates_directory", |b| b.iter(|| 10));
     assert!(dir.path().join("test_creates_directory").is_dir());
+    // Always error
+    panic!();
 }
 
 #[test]


### PR DESCRIPTION
Demo for #50. The `panic!()` makes 1 test fail, but `cargo test` completes without errors. CI should not be passing on this PR!