### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/Boshen/criterion2.rs/compare/v1.0.0...v1.1.0) - 2024-08-27
+
+### Added
+- add `Bencher::iter_with_setup_wrapper` ([#49](https://github.com/Boshen/criterion2.rs/pull/49))
+
+### Fixed
+- fix integration tests not being run
+
 ## [0.11.0](https://github.com/Boshen/criterion2.rs/compare/v0.10.0...v0.11.0) - 2024-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -375,7 +375,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "1.0.0"
+version = "1.1.0"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 1.0.0 -> 1.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/Boshen/criterion2.rs/compare/v1.0.0...v1.1.0) - 2024-08-27

### Added
- add `Bencher::iter_with_setup_wrapper` ([#49](https://github.com/Boshen/criterion2.rs/pull/49))

### Fixed
- fix integration tests not being run
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).