### PR TITLE
chore: release v1.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [1.1.1](https://github.com/Boshen/criterion2.rs/compare/v1.1.0...v1.1.1) - 2024-09-23
+
+### Other
+
+- *(renovate)* bump crates
+- *(deps)* update rust crates ([#56](https://github.com/Boshen/criterion2.rs/pull/56))
+- *(deps)* update dependency rust to v1.81.0 ([#55](https://github.com/Boshen/criterion2.rs/pull/55))
+- rust v1.80.1
+
 ## [1.1.0](https://github.com/Boshen/criterion2.rs/compare/v1.0.0...v1.1.0) - 2024-08-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "1.1.0"
+version = "1.1.1"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "1.1.0"
+version = "1.1.1"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 1.1.0 -> 1.1.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.1](https://github.com/Boshen/criterion2.rs/compare/v1.1.0...v1.1.1) - 2024-09-23

### Other

- *(renovate)* bump crates
- *(deps)* update rust crates ([#56](https://github.com/Boshen/criterion2.rs/pull/56))
- *(deps)* update dependency rust to v1.81.0 ([#55](https://github.com/Boshen/criterion2.rs/pull/55))
- rust v1.80.1
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).