### PR TITLE
chore: release v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.0.0](https://github.com/Boshen/criterion2.rs/compare/v1.1.1...v2.0.0) - 2024-10-31
+
+### Other
+
+- Make filters to look for a substring unless exact is given ([#65](https://github.com/Boshen/criterion2.rs/pull/65))
+- *(deps)* update rust crates ([#64](https://github.com/Boshen/criterion2.rs/pull/64))
+- *(deps)* update rust crate serde_json to 1.0.132 ([#63](https://github.com/Boshen/criterion2.rs/pull/63))
+- *(deps)* update dependency rust to v1.82.0 ([#62](https://github.com/Boshen/criterion2.rs/pull/62))
+- *(deps)* update rust crate bpaf to 0.9.15 ([#61](https://github.com/Boshen/criterion2.rs/pull/61))
+- *(deps)* update rust crate futures to 0.3.31 ([#60](https://github.com/Boshen/criterion2.rs/pull/60))
+- *(deps)* update rust crate tempfile to 3.13.0 ([#59](https://github.com/Boshen/criterion2.rs/pull/59))
+- *(deps)* update rust crates ([#57](https://github.com/Boshen/criterion2.rs/pull/57))
+
 ## [1.1.1](https://github.com/Boshen/criterion2.rs/compare/v1.1.0...v1.1.1) - 2024-09-23
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,7 +340,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "1.1.1"
+version = "2.0.0"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "1.1.1"
+version = "2.0.0"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION
## 🤖 New release
* `criterion2`: 1.1.1 -> 2.0.0 (⚠️ API breaking changes)

### ⚠️ `criterion2` breaking changes

```
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.36.0/src/lints/enum_variant_added.ron

Failed in:
  variant BenchmarkFilter:Substring in /tmp/.tmp3ujhlx/criterion2.rs/src/lib.rs:295
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [2.0.0](https://github.com/Boshen/criterion2.rs/compare/v1.1.1...v2.0.0) - 2024-10-31

### Other

- Make filters to look for a substring unless exact is given ([#65](https://github.com/Boshen/criterion2.rs/pull/65))
- *(deps)* update rust crates ([#64](https://github.com/Boshen/criterion2.rs/pull/64))
- *(deps)* update rust crate serde_json to 1.0.132 ([#63](https://github.com/Boshen/criterion2.rs/pull/63))
- *(deps)* update dependency rust to v1.82.0 ([#62](https://github.com/Boshen/criterion2.rs/pull/62))
- *(deps)* update rust crate bpaf to 0.9.15 ([#61](https://github.com/Boshen/criterion2.rs/pull/61))
- *(deps)* update rust crate futures to 0.3.31 ([#60](https://github.com/Boshen/criterion2.rs/pull/60))
- *(deps)* update rust crate tempfile to 3.13.0 ([#59](https://github.com/Boshen/criterion2.rs/pull/59))
- *(deps)* update rust crates ([#57](https://github.com/Boshen/criterion2.rs/pull/57))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).