### PR TITLE
Make filters to look for a substring unless exact is given

### DIFF
--- a/src/criterion.rs
+++ b/src/criterion.rs
@@ -379,9 +379,12 @@ impl<M: Measurement> Criterion<M> {
             // --ignored overwrites any name-based filters passed in.
             BenchmarkFilter::RejectAll
         } else if let Some(filter) = opts.filter.as_ref() {
-            // if opts.exact {
-            BenchmarkFilter::Exact(filter.to_owned())
-            // }
+            let filter = filter.to_owned();
+            if opts.exact {
+                BenchmarkFilter::Exact(filter)
+            } else {
+                BenchmarkFilter::Substring(filter)
+            }
         } else {
             BenchmarkFilter::AcceptAll
         };
@@ -475,6 +478,7 @@ impl<M: Measurement> Criterion<M> {
             BenchmarkFilter::AcceptAll => true,
             BenchmarkFilter::Exact(exact) => id == exact,
             BenchmarkFilter::RejectAll => false,
+            BenchmarkFilter::Substring(s) => id.contains(s),
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -291,6 +291,8 @@ pub enum BenchmarkFilter {
     AcceptAll,
     /// Run the benchmark matching this string exactly.
     Exact(String),
+    /// Look for benchmark that contain substring
+    Substring(String),
     /// Do not run any benchmarks.
     RejectAll,
 }


### PR DESCRIPTION
eecce42 removed partial filter matches to improve compilation speed, but we can still do something similar without using regex crate by looking for a substring. Plus I'd get regex back and put it behind a feature flag, those who care - can keep using it.