### PR TITLE
chore: release v3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [3.0.1](https://github.com/Boshen/criterion2.rs/compare/v3.0.0...v3.0.1) - 2025-03-23
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#94](https://github.com/Boshen/criterion2.rs/pull/94))
+- *(deps)* update dependency rust to v1.85.1 ([#92](https://github.com/Boshen/criterion2.rs/pull/92))
+
 ## [2.0.0](https://github.com/Boshen/criterion2.rs/compare/v1.1.1...v2.0.0) - 2024-10-31
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -344,7 +344,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "3.0.0"
+version = "3.0.1"
 authors = [
   "Brook Heisler <brookheisler@gmail.com>",
   "Jorge Aparicio <japaricious@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `criterion2`: 3.0.0 -> 3.0.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [3.0.1](https://github.com/Boshen/criterion2.rs/compare/v3.0.0...v3.0.1) - 2025-03-23

### Other

- *(deps)* lock file maintenance rust crates ([#94](https://github.com/Boshen/criterion2.rs/pull/94))
- *(deps)* update dependency rust to v1.85.1 ([#92](https://github.com/Boshen/criterion2.rs/pull/92))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).