### PR TITLE
chore: release v3.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,27 @@
 
 All notable changes to this project will be documented in this file.
 
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [3.0.2](https://github.com/Boshen/criterion2.rs/compare/v3.0.1...v3.0.2) - 2025-07-27
+
+### Other
+
+- *(deps)* lock file maintenance rust crates ([#116](https://github.com/Boshen/criterion2.rs/pull/116))
+- *(deps)* lock file maintenance rust crates ([#115](https://github.com/Boshen/criterion2.rs/pull/115))
+- *(deps)* lock file maintenance rust crates ([#114](https://github.com/Boshen/criterion2.rs/pull/114))
+- *(deps)* lock file maintenance rust crates ([#113](https://github.com/Boshen/criterion2.rs/pull/113))
+- *(deps)* update rust crate codspeed to v3 ([#111](https://github.com/Boshen/criterion2.rs/pull/111))
+- *(deps)* lock file maintenance rust crates ([#112](https://github.com/Boshen/criterion2.rs/pull/112))
+- *(deps)* lock file maintenance ([#110](https://github.com/Boshen/criterion2.rs/pull/110))
+- update release-plz.yml
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,7 +369,7 @@ dependencies = [
 
 [[package]]
 name = "criterion2"
-version = "3.0.1"
+version = "3.0.2"
 dependencies = [
  "anes",
  "approx",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "criterion2"
-version = "3.0.1"
+version = "3.0.2"
 authors = [
   "Boshen <boshenc@gmail.com>",
   "Brook Heisler <brookheisler@gmail.com>",


### PR DESCRIPTION



## 🤖 New release

* `criterion2`: 3.0.1 -> 3.0.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>



</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).