### PR TITLE
chore(deps): drop walkdir in favor of std recursion

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -382,7 +382,6 @@ dependencies = [
  "smol",
  "tempfile",
  "tokio",
- "walkdir",
 ]
 
 [[package]]
@@ -928,15 +927,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1085,16 +1075,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1205,15 +1185,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,6 @@ serde      = "1.0.228"
 serde_json = "1.0.150"
 ciborium   = "0.2.2"
 bpaf       = { version = "0.9.26", default-features = false }
-walkdir    = "2.5"
 cast       = "0.3"
 num-traits = { version = "0.2.19", default-features = false, features = ["std"] }
 oorandom   = "11.1.5"

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -2,11 +2,10 @@ use std::{
     ffi::OsStr,
     fs::{self, File},
     io::Read,
-    path::Path,
+    path::{Path, PathBuf},
 };
 
 use serde::{Serialize, de::DeserializeOwned};
-use walkdir::{DirEntry, WalkDir};
 
 use crate::{
     error::{Error, Result},
@@ -82,22 +81,34 @@ pub fn list_existing_benchmarks<P>(directory: &P) -> Result<Vec<BenchmarkId>>
 where
     P: AsRef<Path>,
 {
-    fn is_benchmark(entry: &DirEntry) -> bool {
+    fn is_benchmark(path: &Path) -> bool {
         // Look for benchmark.json files inside folders named "new" (because we want to ignore
         // the baselines)
-        entry.file_name() == OsStr::new("benchmark.json")
-            && entry.path().parent().unwrap().file_name().unwrap() == OsStr::new("new")
+        path.file_name() == Some(OsStr::new("benchmark.json"))
+            && path.parent().and_then(Path::file_name) == Some(OsStr::new("new"))
     }
 
-    let mut ids = vec![];
+    // Recursively collect every file under `directory`, ignoring any I/O errors
+    // (e.g. unreadable directories) the same way the previous `walkdir` based
+    // implementation did.
+    fn visit(dir: &Path, files: &mut Vec<PathBuf>) {
+        let Ok(entries) = fs::read_dir(dir) else { return };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            match entry.file_type() {
+                Ok(file_type) if file_type.is_dir() => visit(&path, files),
+                Ok(_) => files.push(path),
+                Err(_) => {}
+            }
+        }
+    }
 
-    for entry in WalkDir::new(directory)
-        .into_iter()
-        // Ignore errors.
-        .filter_map(::std::result::Result::ok)
-        .filter(is_benchmark)
-    {
-        let id: BenchmarkId = load(entry.path())?;
+    let mut paths = vec![];
+    visit(directory.as_ref(), &mut paths);
+
+    let mut ids = vec![];
+    for path in paths.into_iter().filter(|p| is_benchmark(p)) {
+        let id: BenchmarkId = load(&path)?;
         ids.push(id);
     }
 

--- a/tests/criterion_tests.rs
+++ b/tests/criterion_tests.rs
@@ -10,7 +10,21 @@ use std::{
 use criterion::{BatchSize, BenchmarkFilter, BenchmarkId, Criterion, profiler::Profiler};
 use serde_json::value::Value;
 use tempfile::{TempDir, tempdir};
-use walkdir::WalkDir;
+
+/// Recursively collect every file and directory entry under `dir`.
+fn walk(dir: &Path) -> Vec<PathBuf> {
+    let mut entries = vec![];
+    if let Ok(read_dir) = std::fs::read_dir(dir) {
+        for entry in read_dir.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                entries.extend(walk(&path));
+            }
+            entries.push(path);
+        }
+    }
+    entries
+}
 
 /*
  * Please note that these tests are not complete examples of how to use
@@ -76,9 +90,8 @@ fn verify_not_exists(dir: &Path, path: &str) {
 
 fn latest_modified(dir: &Path) -> SystemTime {
     let mut newest_update: Option<SystemTime> = None;
-    for entry in WalkDir::new(dir) {
-        let entry = entry.unwrap();
-        let modified = entry.metadata().unwrap().modified().unwrap();
+    for path in std::iter::once(dir.to_path_buf()).chain(walk(dir)) {
+        let modified = path.metadata().unwrap().modified().unwrap();
         newest_update = match newest_update {
             Some(latest) => Some(max(latest, modified)),
             None => Some(modified),
@@ -100,18 +113,13 @@ fn test_without_plots() {
     let dir = temp_dir();
     short_benchmark(&dir).bench_function("test_without_plots", |b| b.iter(|| 10));
 
-    for entry in WalkDir::new(dir.path().join("test_without_plots")) {
-        let entry = entry.ok();
-        let is_svg = entry
-            .as_ref()
-            .and_then(|entry| entry.path().extension())
-            .and_then(|ext| ext.to_str())
-            .map(|ext| ext == "svg")
-            .unwrap_or(false);
+    for path in walk(&dir.path().join("test_without_plots")) {
+        let is_svg =
+            path.extension().and_then(|ext| ext.to_str()).map(|ext| ext == "svg").unwrap_or(false);
         assert!(
             !is_svg,
             "Found SVG file ({:?}) in output directory with plots disabled",
-            entry.unwrap().file_name()
+            path.file_name()
         );
     }
 }


### PR DESCRIPTION
Removes the `walkdir` dependency. It was only used in one place — `fs::list_existing_benchmarks` — to recursively find `benchmark.json` files. A small recursive `std::fs::read_dir` walk does the same job.

This also drops the transitive `same-file` (and `winapi-util` on Windows) crates from the tree.

The two `walkdir` call sites in the integration tests are replaced with a local `walk` helper using the same std recursion.