### PR TITLE
ci: make the MSRV job actually test its MSRV toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -17,11 +17,17 @@ jobs:
       matrix:
         rust:
           - stable
-          - 1.70.0 # MSRV
+          - 1.85.0 # MSRV
           - nightly
 
     steps:
       - uses: taiki-e/checkout-action@7d1e50e93dc4fb3bba58f85018fadf77898aee8b # v1.4.2
+
+      # rust-toolchain.toml overrides the installed toolchain for every cargo
+      # invocation, so versioned lanes must opt out of it to test what they claim.
+      - name: Override pinned toolchain for versioned lanes
+        if: ${{ matrix.rust != 'stable' && matrix.rust != 'nightly' }}
+        run: echo "RUSTUP_TOOLCHAIN=${{ matrix.rust }}" >> "$GITHUB_ENV"
 
       - uses: dtolnay/rust-toolchain@fa04a1451ff1842e2626ccb99004d0195b455a88 # master
         name: Setup rust toolchain


### PR DESCRIPTION
The `ci (1.70.0)` matrix lane has not been testing 1.70.0: `rust-toolchain.toml` overrides the installed toolchain for every `cargo` invocation, so all matrix lanes silently build with the pinned toolchain — the job log shows rustup noting `toolchain '1.97.0' is currently in use (overridden by rust-toolchain.toml)`. The lane also predates `rust-version = "1.85.0"` / `edition = "2024"`, which 1.70.0 cannot compile at all.

- Bump the lane to `1.85.0` to match `rust-version` in `Cargo.toml`.
- Export `RUSTUP_TOOLCHAIN` for versioned lanes so the matrix toolchain beats the `rust-toolchain.toml` override. The `stable` and `nightly` lanes intentionally keep the pinned toolchain: Renovate controls toolchain rollout, and a real-nightly lane would make a required check flaky on upstream nightly regressions.

All MSRV-lane steps pass locally under 1.85.0: both builds, all test suites, and the codspeed check.

**Merge note:** branch protection requires the status check `ci (1.70.0)` by name; it must be renamed to `ci (1.85.0)` for this PR (and everything after it) to merge. Happy to flip that right before merging.