### PR TITLE
ci: remove dead WASI test step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -66,17 +66,6 @@ jobs:
         if: ${{ matrix.rust == 'stable' }}
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      # This fails on 1.64, but works on 1.66 and later.
-      # https://github.com/rust-lang/rust/issues/103306
-      - name: Test run targeting WASI
-        if: false # ${{ matrix.rust == 'stable' }}
-        run: |
-          curl https://wasmtime.dev/install.sh -sSf | bash
-          source ~/.bashrc
-          export PATH=$HOME/.wasmtime/bin/:$PATH
-          cargo install cargo-wasi
-          cargo wasi bench --no-default-features -- --test -- # hack to eliminate the `--bench` argument pass in from `cargo wasi`
-
   nextest-compat:
     name: Check compatibility with nextest
     runs-on: ubuntu-latest


### PR DESCRIPTION
The `Test run targeting WASI` step in `ci.yaml` has been permanently disabled via `if: false` and references Rust 1.64/1.66 — long predating the current 1.85.0 MSRV. It has never run in this fork, so remove the dead configuration.